### PR TITLE
Fix method on_label_removal

### DIFF
--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -494,8 +494,8 @@ class GhLabelSynchronizer:
             return False
 
         coms = self.get_commits()
-        authors = [com['authors'] for com in coms]
-        authors = [auth for auth in authors if not auth['login'] in (self._actor, 'github-actions')]
+        authors = [com['authors']['login'] for com in coms]
+        authors = [auth for auth in authors if not auth in (self._actor, 'github-actions')]
         if not authors:
             info('PR %s can\'t be approved by the author %s since no other person commited to it' % (self._issue, self._actor))
             return False

--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -624,7 +624,7 @@ class GhLabelSynchronizer:
         a corresponding other one.
         """
         if type(item) == State:
-            sel_list = 'state'
+            sel_list = 'status'
         else:
             sel_list = 'priority'
         self.add_warning('Label *%s* can not be removed. Please add the %s label which should replace it' % (item.value, sel_list))

--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -627,7 +627,7 @@ class GhLabelSynchronizer:
             sel_list = 'state'
         else:
             sel_list = 'priority'
-        self.add_warning('Label *%s* can not be removed. Please add the %s-label which should replace it' % (item.value, sel_list))
+        self.add_warning('Label *%s* can not be removed. Please add the %s label which should replace it' % (item.value, sel_list))
         self.add_label(item.value)
         return
 
@@ -715,6 +715,10 @@ class GhLabelSynchronizer:
             return
 
         item = sel_list(label)
+
+        if len(self.active_partners(item)) > 0:
+            return
+
         if sel_list is State:
             if self.is_pull_request():
                 if item != State.needs_info:

--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -494,8 +494,15 @@ class GhLabelSynchronizer:
             return False
 
         coms = self.get_commits()
-        authors = [com['authors']['login'] for com in coms]
-        authors = [auth for auth in authors if not auth in (self._actor, 'github-actions')]
+        authors = []
+        for com in coms:
+            for author in com['authors']:
+                login = author['login']
+                if not login in authors:
+                    if not login in (self._actor, 'github-actions')
+                        debug('PR %s has recent commit by %s' % (self._issue, login))
+                        authors.append(login)
+
         if not authors:
             info('PR %s can\'t be approved by the author %s since no other person commited to it' % (self._issue, self._actor))
             return False

--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -499,7 +499,7 @@ class GhLabelSynchronizer:
             for author in com['authors']:
                 login = author['login']
                 if not login in authors:
-                    if not login in (self._actor, 'github-actions')
+                    if not login in (self._actor, 'github-actions'):
                         debug('PR %s has recent commit by %s' % (self._issue, login))
                         authors.append(login)
 

--- a/.github/sync_labels.py
+++ b/.github/sync_labels.py
@@ -494,7 +494,7 @@ class GhLabelSynchronizer:
             return False
 
         coms = self.get_commits()
-        authors = sum(com['authors'] for com in coms)
+        authors = [com['authors'] for com in coms]
         authors = [auth for auth in authors if not auth['login'] in (self._actor, 'github-actions')]
         if not authors:
             info('PR %s can\'t be approved by the author %s since no other person commited to it' % (self._issue, self._actor))


### PR DESCRIPTION
<!-- ^^^^^
Please provide a concise, informative and self-explanatory title.
Don't put issue numbers in there, do this in the PR body below.
For example, instead of "Fixes #1234" use "Introduce new method to calculate 1+1"
-->
<!-- Describe your changes here in detail -->

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

This PR fixes a bug which has been noticed by an accidentally activation of the `unlabeled` trigger (see https://github.com/sagemath/sage/pull/36292#issuecomment-1723266908). Simultanously the `labeled`-trigger has been disabled. This is an unrealistic setting which is not covered by the code.

Explicitely, a state label could not be removed even though other state labels where set (examples  https://github.com/sagemath/sage/pull/36128 and https://github.com/sagemath/sage/pull/36020). This PR leads to the following changes of behavior:

1. The reaction on the `unlabeled`-event is reduced to the case of the last label
2. The `unlabeled`-event will not lead to a rejection of the removal any more
3. Instead of a warning comment a hint comment is posted.

Furthermore, a bug in `actor_valid` is fixed, which showed up while testing and some minor typo fixes noticed by the review are done.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->


<a href="https://gitpod.io/#https://github.com/soehms/sage/pull/10"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

